### PR TITLE
Fix horizontal scroll on mobile

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,3 +5,13 @@
 body {
   @apply bg-[#1a202c]
 }
+
+html,
+body {
+  overflow-x: hidden;
+  scroll-behavior: smooth;
+}
+
+body {
+  position: relative;
+}


### PR DESCRIPTION
Thanks again for this repo.

On mobile, the framer intro animation caused the page width to be larger than it actually is, causing horizontal scrolling into empty space.

Per https://stackoverflow.com/a/68913161 this is a CSS fix for that.